### PR TITLE
Add circle drawing and keyboard controls with Siv3D

### DIFF
--- a/julesSiv3DTest/Main.cpp
+++ b/julesSiv3DTest/Main.cpp
@@ -1,86 +1,30 @@
-﻿# include <Siv3D.hpp> // OpenSiv3D v0.6.5
+#include <Siv3D.hpp>
 
 void Main()
 {
-	// 背景の色を設定 | Set background color
-	Scene::SetBackground(ColorF{ 0.8, 0.9, 1.0 });
+    s3d::Scene::SetBackground(s3d::ColorF{ 0.8, 0.9, 1.0 });
 
-	// 通常のフォントを作成 | Create a new font
-	const Font font{ 60 };
+    s3d::Vec2 playerPosition{ 400, 300 };
 
-	// 絵文字用フォントを作成 | Create a new emoji font
-	const Font emojiFont{ 60, Typeface::ColorEmoji };
+    while (s3d::System::Update())
+    {
+        if (s3d::KeyW.pressed())
+        {
+            playerPosition.y -= 5.0;
+        }
+        if (s3d::KeyS.pressed())
+        {
+            playerPosition.y += 5.0;
+        }
+        if (s3d::KeyA.pressed())
+        {
+            playerPosition.x -= 5.0;
+        }
+        if (s3d::KeyD.pressed())
+        {
+            playerPosition.x += 5.0;
+        }
 
-	// `font` が絵文字用フォントも使えるようにする | Set emojiFont as a fallback
-	font.addFallback(emojiFont);
-
-	// 画像ファイルからテクスチャを作成 | Create a texture from an image file
-	const Texture texture{ U"example/windmill.png" };
-
-	// 絵文字からテクスチャを作成 | Create a texture from an emoji
-	const Texture emoji{ U"🐈"_emoji };
-
-	// 絵文字を描画する座標 | Coordinates of the emoji
-	Vec2 emojiPos{ 300, 150 };
-
-	// テキストを画面にデバッグ出力 | Print a text
-	Print << U"Push [A] key";
-
-	while (System::Update())
-	{
-		// テクスチャを描く | Draw a texture
-		texture.draw(200, 200);
-
-		// テキストを画面の中心に描く | Put a text in the middle of the screen
-		font(U"Hello, Siv3D!🚀").drawAt(Scene::Center(), Palette::Black);
-
-		// サイズをアニメーションさせて絵文字を描く | Draw a texture with animated size
-		emoji.resized(100 + Periodic::Sine0_1(1s) * 20).drawAt(emojiPos);
-
-		// マウスカーソルに追随する半透明な円を描く | Draw a red transparent circle that follows the mouse cursor
-		Circle{ Cursor::Pos(), 40 }.draw(ColorF{ 1, 0, 0, 0.5 });
-
-		// もし [A] キーが押されたら | When [A] key is down
-		if (KeyA.down())
-		{
-			// 選択肢からランダムに選ばれたメッセージをデバッグ表示 | Print a randomly selected text
-			Print << Sample({ U"Hello!", U"こんにちは", U"你好", U"안녕하세요?" });
-		}
-
-		// もし [Button] が押されたら | When [Button] is pushed
-		if (SimpleGUI::Button(U"Button", Vec2{ 640, 40 }))
-		{
-			// 画面内のランダムな場所に座標を移動
-			// Move the coordinates to a random position in the screen
-			emojiPos = RandomVec2(Scene::Rect());
-		}
-	}
+        s3d::Circle(playerPosition, 30).draw(s3d::Palette::Orange);
+    }
 }
-
-//
-// - Debug ビルド: プログラムの最適化を減らす代わりに、エラーやクラッシュ時に詳細な情報を得られます。
-//
-// - Release ビルド: 最大限の最適化でビルドします。
-//
-// - [デバッグ] メニュー → [デバッグの開始] でプログラムを実行すると、[出力] ウィンドウに詳細なログが表示され、エラーの原因を探せます。
-//
-// - Visual Studio を更新した直後は、プログラムのリビルド（[ビルド]メニュー → [ソリューションのリビルド]）が必要です。
-//
-// チュートリアル
-// https://siv3d.github.io/ja-jp/tutorial/tutorial/
-//
-// Tutorial
-// https://siv3d.github.io/tutorial/tutorial/
-//
-// Siv3D コミュニティへの参加（Discord などで気軽に質問や交流, 最新情報の入手ができます）
-// https://siv3d.github.io/ja-jp/community/community/
-//
-// Siv3D User Community
-// https://siv3d.github.io/community/community/
-//
-// 新機能の提案やバグの報告 | Feedback
-// https://siv3d.github.io/ja-jp/develop/report/
-//
-// Sponsoring Siv3D
-// https://github.com/sponsors/Reputeless
-//


### PR DESCRIPTION
This commit implements a C++ program using the Siv3D library (v0.6.16) to:
1. Display a window.
2. Draw an orange circle with a radius of 30 pixels.
3. Initialize the circle's position to (400, 300).
4. Allow you to control the circle's position using W, A, S, and D keys.
   - W moves the circle up.
   - A moves the circle left.
   - S moves the circle down.
   - D moves the circle right. Each key press moves the circle by 5.0 units.

All Siv3D library calls explicitly use the `s3d::` namespace as you requested. The program is contained within the `Main.cpp` file, inside the `void Main()` function. Unnecessary example code has been removed.